### PR TITLE
Update server.js

### DIFF
--- a/app/templates/server.js
+++ b/app/templates/server.js
@@ -3,7 +3,8 @@ var express = require('express'),
     cfg = require('./app/core/config'),
     router = require('./app/core/router'),
     hbs = require('./app/core/hbs'),
-    bodyParser = require('body-parser');
+    bodyParser = require('body-parser'),
+	port = process.env.PORT || 8080;
 
 // Loads custom project routes
 require('./app/core/routeLoader')(app);
@@ -15,6 +16,6 @@ app.set('views', cfg.splendid.view_directory);
 app.engine(cfg.splendid.view_file_extension, hbs.__express);
 
 
-app.listen(8080, function() {
-    console.log('Splendid listening on *:8080');
+app.listen(port, function() {
+    console.log('Splendid listening on *:%S', port);
 });


### PR DESCRIPTION
Make setting of port flexible.
The application now can be started with a port other than the default (8080) by setting a process.env variable.

e.g.: $ PORT=8081 node server.js